### PR TITLE
Enum filtering

### DIFF
--- a/graphene_django/filter/fields.py
+++ b/graphene_django/filter/fields.py
@@ -43,8 +43,8 @@ class DjangoFilterConnectionField(DjangoConnectionField):
             if self._extra_filter_meta:
                 meta.update(self._extra_filter_meta)
 
-            filterset_class = self._provided_filterset_class or (
-                self.node_type._meta.filterset_class
+            filterset_class = (
+                self._provided_filterset_class or self.node_type._meta.filterset_class
             )
             self._filterset_class = get_filterset_class(filterset_class, **meta)
 

--- a/graphene_django/filter/filters.py
+++ b/graphene_django/filter/filters.py
@@ -38,7 +38,7 @@ class InFilter(Filter):
 
     def filter(self, qs, value):
         """
-        Override the default filter class to check first weather the list is
+        Override the default filter class to check first whether the list is
         empty or not.
         This needs to be done as in this case we expect to get an empty output
         (if not an exclude filter) but django_filter consider an empty list

--- a/graphene_django/filter/tests/filters.py
+++ b/graphene_django/filter/tests/filters.py
@@ -10,7 +10,7 @@ class ArticleFilter(django_filters.FilterSet):
         fields = {
             "headline": ["exact", "icontains"],
             "pub_date": ["gt", "lt", "exact"],
-            "reporter": ["exact"],
+            "reporter": ["exact", "in"],
         }
 
     order_by = OrderingFilter(fields=("pub_date",))

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -87,6 +87,7 @@ def test_filter_explicit_filterset_arguments():
         "pub_date__gt",
         "pub_date__lt",
         "reporter",
+        "reporter__in",
     )
 
 

--- a/graphene_django/filter/tests/test_in_filter.py
+++ b/graphene_django/filter/tests/test_in_filter.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from django_filters import FilterSet
@@ -5,7 +7,8 @@ from django_filters import rest_framework as filters
 from graphene import ObjectType, Schema
 from graphene.relay import Node
 from graphene_django import DjangoObjectType
-from graphene_django.tests.models import Pet, Person
+from graphene_django.tests.models import Pet, Person, Reporter, Article, Film
+from graphene_django.filter.tests.filters import ArticleFilter
 from graphene_django.utils import DJANGO_FILTER_INSTALLED
 
 pytestmark = []
@@ -20,40 +23,62 @@ else:
     )
 
 
-class PetNode(DjangoObjectType):
-    class Meta:
-        model = Pet
-        interfaces = (Node,)
-        filter_fields = {
-            "name": ["exact", "in"],
-            "age": ["exact", "in", "range"],
-        }
+@pytest.fixture
+def query():
+    class PetNode(DjangoObjectType):
+        class Meta:
+            model = Pet
+            interfaces = (Node,)
+            filter_fields = {
+                "name": ["exact", "in"],
+                "age": ["exact", "in", "range"],
+            }
+
+    class ReporterNode(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class ArticleNode(DjangoObjectType):
+        class Meta:
+            model = Article
+            interfaces = (Node,)
+            filterset_class = ArticleFilter
+
+    class FilmNode(DjangoObjectType):
+        class Meta:
+            model = Film
+            interfaces = (Node,)
+            filter_fields = {
+                "genre": ["exact", "in"],
+            }
+
+    class PersonFilterSet(FilterSet):
+        class Meta:
+            model = Person
+            fields = {}
+
+        names = filters.BaseInFilter(method="filter_names")
+
+        def filter_names(self, qs, name, value):
+            return qs.filter(name__in=value)
+
+    class PersonNode(DjangoObjectType):
+        class Meta:
+            model = Person
+            interfaces = (Node,)
+            filterset_class = PersonFilterSet
+
+    class Query(ObjectType):
+        pets = DjangoFilterConnectionField(PetNode)
+        people = DjangoFilterConnectionField(PersonNode)
+        articles = DjangoFilterConnectionField(ArticleNode)
+        films = DjangoFilterConnectionField(FilmNode)
+
+    return Query
 
 
-class PersonFilterSet(FilterSet):
-    class Meta:
-        model = Person
-        fields = {}
-
-    names = filters.BaseInFilter(method="filter_names")
-
-    def filter_names(self, qs, name, value):
-        return qs.filter(name__in=value)
-
-
-class PersonNode(DjangoObjectType):
-    class Meta:
-        model = Person
-        interfaces = (Node,)
-        filterset_class = PersonFilterSet
-
-
-class Query(ObjectType):
-    pets = DjangoFilterConnectionField(PetNode)
-    people = DjangoFilterConnectionField(PersonNode)
-
-
-def test_string_in_filter():
+def test_string_in_filter(query):
     """
     Test in filter on a string field.
     """
@@ -61,7 +86,7 @@ def test_string_in_filter():
     Pet.objects.create(name="Mimi", age=3)
     Pet.objects.create(name="Jojo, the rabbit", age=3)
 
-    schema = Schema(query=Query)
+    schema = Schema(query=query)
 
     query = """
     query {
@@ -82,13 +107,13 @@ def test_string_in_filter():
     ]
 
 
-def test_string_in_filter_with_filterset_class():
+def test_string_in_filter_with_filterset_class(query):
     """Test in filter on a string field with a custom filterset class."""
     Person.objects.create(name="John")
     Person.objects.create(name="Michael")
     Person.objects.create(name="Angela")
 
-    schema = Schema(query=Query)
+    schema = Schema(query=query)
 
     query = """
     query {
@@ -109,7 +134,7 @@ def test_string_in_filter_with_filterset_class():
     ]
 
 
-def test_int_in_filter():
+def test_int_in_filter(query):
     """
     Test in filter on an integer field.
     """
@@ -117,7 +142,7 @@ def test_int_in_filter():
     Pet.objects.create(name="Mimi", age=3)
     Pet.objects.create(name="Jojo, the rabbit", age=3)
 
-    schema = Schema(query=Query)
+    schema = Schema(query=query)
 
     query = """
     query {
@@ -157,7 +182,7 @@ def test_int_in_filter():
     ]
 
 
-def test_in_filter_with_empty_list():
+def test_in_filter_with_empty_list(query):
     """
     Check that using a in filter with an empty list provided as input returns no objects.
     """
@@ -165,7 +190,7 @@ def test_in_filter_with_empty_list():
     Pet.objects.create(name="Mimi", age=8)
     Pet.objects.create(name="Picotin", age=5)
 
-    schema = Schema(query=Query)
+    schema = Schema(query=query)
 
     query = """
     query {
@@ -181,3 +206,181 @@ def test_in_filter_with_empty_list():
     result = schema.execute(query)
     assert not result.errors
     assert len(result.data["pets"]["edges"]) == 0
+
+
+def test_enum_in_filter_string(graphene_settings, query):
+    """
+    Test in filter on an enum field.
+    """
+    graphene_settings.USE_ENUM_TYPE_IN_FILTER = False
+
+    john_doe = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="john@doe.com"
+    )
+    jean_bon = Reporter.objects.create(
+        first_name="Jean", last_name="Bon", email="jean@bon.com"
+    )
+    documentary_film = Film.objects.create(genre="do")
+    documentary_film.reporters.add(john_doe)
+    action_film = Film.objects.create(genre="ac")
+    action_film.reporters.add(john_doe)
+    other_film = Film.objects.create(genre="ot")
+    other_film.reporters.add(john_doe)
+    other_film.reporters.add(jean_bon)
+
+    schema = Schema(query=query)
+
+    query = """
+    query {
+        films (genre_In: ["do", "ac"]) {
+            edges {
+                node {
+                    genre
+                    reporters {
+                        edges {
+                            node {
+                                lastName
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["films"]["edges"] == [
+        {
+            "node": {
+                "genre": "DO",
+                "reporters": {"edges": [{"node": {"lastName": "Doe"}}]},
+            }
+        },
+        {
+            "node": {
+                "genre": "AC",
+                "reporters": {"edges": [{"node": {"lastName": "Doe"}}]},
+            }
+        },
+    ]
+
+
+def test_enum_in_filter_native(graphene_settings, query):
+    """
+    Test in filter on an enum field.
+    """
+    graphene_settings.USE_ENUM_TYPE_IN_FILTER = True
+
+    john_doe = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="john@doe.com"
+    )
+    jean_bon = Reporter.objects.create(
+        first_name="Jean", last_name="Bon", email="jean@bon.com"
+    )
+    documentary_film = Film.objects.create(genre="do")
+    documentary_film.reporters.add(john_doe)
+    action_film = Film.objects.create(genre="ac")
+    action_film.reporters.add(john_doe)
+    other_film = Film.objects.create(genre="ot")
+    other_film.reporters.add(john_doe)
+    other_film.reporters.add(jean_bon)
+
+    schema = Schema(query=query)
+
+    query = """
+    query {
+        films (genre_In: [DO, AC]) {
+            edges {
+                node {
+                    genre
+                    reporters {
+                        edges {
+                            node {
+                                lastName
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["films"]["edges"] == [
+        {
+            "node": {
+                "genre": "DO",
+                "reporters": {"edges": [{"node": {"lastName": "Doe"}}]},
+            }
+        },
+        {
+            "node": {
+                "genre": "AC",
+                "reporters": {"edges": [{"node": {"lastName": "Doe"}}]},
+            }
+        },
+    ]
+
+
+def test_fk_id_in_filter(query):
+    """
+    Test in filter on an foreign key relationship.
+    """
+    john_doe = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="john@doe.com"
+    )
+    jean_bon = Reporter.objects.create(
+        first_name="Jean", last_name="Bon", email="jean@bon.com"
+    )
+    sara_croche = Reporter.objects.create(
+        first_name="Sara", last_name="Croche", email="sara@croche.com"
+    )
+    Article.objects.create(
+        headline="A",
+        pub_date=datetime.now(),
+        pub_date_time=datetime.now(),
+        reporter=john_doe,
+        editor=john_doe,
+    )
+    Article.objects.create(
+        headline="B",
+        pub_date=datetime.now(),
+        pub_date_time=datetime.now(),
+        reporter=jean_bon,
+        editor=jean_bon,
+    )
+    Article.objects.create(
+        headline="C",
+        pub_date=datetime.now(),
+        pub_date_time=datetime.now(),
+        reporter=sara_croche,
+        editor=sara_croche,
+    )
+
+    schema = Schema(query=query)
+
+    query = """
+    query {
+        articles (reporter_In: [%s, %s]) {
+            edges {
+                node {
+                    headline
+                    reporter {
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+    """ % (
+        john_doe.id,
+        jean_bon.id,
+    )
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data["articles"]["edges"] == [
+        {"node": {"headline": "A", "reporter": {"lastName": "Doe"}}},
+        {"node": {"headline": "B", "reporter": {"lastName": "Bon"}}},
+    ]

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -105,7 +105,11 @@ def replace_csv_filters(filterset_class):
     for name, filter_field in six.iteritems(filterset_class.base_filters):
         filter_type = filter_field.lookup_expr
         if filter_type in {"in", "contains", "overlap"}:
-            filterset_class.base_filters[name] = InFilter(
+
+            class CustomInFilter(InFilter):
+                field_class = filter_field.field_class
+
+            filterset_class.base_filters[name] = CustomInFilter(
                 field_name=filter_field.field_name,
                 lookup_expr=filter_field.lookup_expr,
                 label=filter_field.label,
@@ -115,7 +119,11 @@ def replace_csv_filters(filterset_class):
             )
 
         elif filter_type == "range":
-            filterset_class.base_filters[name] = RangeFilter(
+
+            class CustomRangeFilter(RangeFilter):
+                field_class = filter_field.field_class
+
+            filterset_class.base_filters[name] = CustomRangeFilter(
                 field_name=filter_field.field_name,
                 lookup_expr=filter_field.lookup_expr,
                 label=filter_field.label,

--- a/graphene_django/filter/utils.py
+++ b/graphene_django/filter/utils.py
@@ -5,6 +5,7 @@ import graphene
 from django_filters.utils import get_model_field
 from django_filters.filters import Filter, BaseCSVFilter
 
+from ..settings import graphene_settings
 from .filterset import custom_filterset_factory, setup_filterset
 from .filters import InFilter, RangeFilter
 
@@ -48,6 +49,28 @@ def get_filtering_args_from_filterset(filterset_class, type):
             field = graphene.List(field.get_type())
 
         field_type = field.Argument()
+
+        if graphene_settings.USE_ENUM_TYPE_IN_FILTER:
+
+            filter_field_custom = type._meta.fields.get(filter_field.field_name, None)
+
+            if filter_field_custom is not None:
+
+                filter_field_type = filter_field_custom.type
+
+                if isinstance(filter_field_type, graphene.NonNull):
+                    filter_field_type = filter_field_type.of_type
+
+                if isinstance(filter_field_type, graphene.types.enum.EnumMeta):
+
+                    required = filter_field.extra.get("required", False)
+
+                    if filter_type == "exact":
+                        field_type = filter_field_type(required=required)
+
+                    elif filter_type in {"in", "contains", "overlap"}:
+                        field_type = graphene.List(filter_field_type, required=required)
+
         field_type.description = filter_field.label
         args[name] = field_type
 

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -39,6 +39,8 @@ DEFAULTS = {
     # Set to True to enable v3 naming convention for choice field Enum's
     "DJANGO_CHOICE_FIELD_ENUM_V3_NAMING": False,
     "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
+    # Set to True to use native Enums in filters
+    "USE_ENUM_TYPE_IN_FILTER": False,
     # Use a separate path for handling subscriptions.
     "SUBSCRIPTION_PATH": None,
     # By default GraphiQL headers editor tab is enabled, set to False to hide it

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -26,7 +26,7 @@ class Film(models.Model):
     genre = models.CharField(
         max_length=2,
         help_text="Genre",
-        choices=[("do", "Documentary"), ("ot", "Other")],
+        choices=[("do", "Documentary"), ("ac", "Action"), ("ot", "Other")],
         default="ot",
     )
     reporters = models.ManyToManyField("Reporter", related_name="films")

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -479,6 +479,86 @@ def test_should_query_node_filtering():
 @pytest.mark.skipif(
     not DJANGO_FILTER_INSTALLED, reason="django-filter should be installed"
 )
+def test_should_query_node_filtering_native_enum(graphene_settings):
+    graphene_settings.USE_ENUM_TYPE_IN_FILTER = True
+
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class ArticleType(DjangoObjectType):
+        class Meta:
+            model = Article
+            interfaces = (Node,)
+            filter_fields = ("lang",)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    r = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
+    )
+    Article.objects.create(
+        headline="Article Node 1",
+        pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
+        reporter=r,
+        editor=r,
+        lang="es",
+    )
+    Article.objects.create(
+        headline="Article Node 2",
+        pub_date=datetime.date.today(),
+        pub_date_time=datetime.datetime.now(),
+        reporter=r,
+        editor=r,
+        lang="en",
+    )
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query NodeFilteringQuery {
+            allReporters {
+                edges {
+                    node {
+                        id
+                        articles(lang: ES) {
+                            edges {
+                                node {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {
+        "allReporters": {
+            "edges": [
+                {
+                    "node": {
+                        "id": "UmVwb3J0ZXJUeXBlOjE=",
+                        "articles": {
+                            "edges": [{"node": {"id": "QXJ0aWNsZVR5cGU6MQ=="}}]
+                        },
+                    }
+                }
+            ]
+        }
+    }
+
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected
+
+
+@pytest.mark.skipif(
+    not DJANGO_FILTER_INSTALLED, reason="django-filter should be installed"
+)
 def test_should_query_node_filtering_with_distinct_queryset():
     class FilmType(DjangoObjectType):
         class Meta:


### PR DESCRIPTION
This PR adds an `USE_ENUM_TYPE_IN_FILTER` option (disabled by default, for backwards compatibility),
which uses Enums as filtering fields whenever possible.

Advantages:

- Leverages GraphQL's native enum system
- Naturally sanitizes user input
- Auto-completion!

Example:

![image](https://user-images.githubusercontent.com/4208560/103427653-58ec3a80-4b77-11eb-9543-775c9c208dbd.png)

