### PR TITLE
fix: format_error import

### DIFF
--- a/graphene_django/views.py
+++ b/graphene_django/views.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from graphql import OperationType, get_operation_ast, parse, validate
 from graphql.error import GraphQLError
-from graphql.error import format_error as format_graphql_error
+from graphql.error.graphql_error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 
 from graphene import Schema


### PR DESCRIPTION
After release of `graphql_core` [3.2.1](https://github.com/graphql-python/graphql-core/releases/tag/v3.2.1) the `format_error` function is not exposed directly in the `__init__.py` so we need to update the import path (in [this commit](https://github.com/graphql-python/graphql-core/commit/09ff14f68bdce1e9cd71decc871fd38274b01971)).
Note that the method still exist and the return type has been updated to be more specific but it is still the same thing.