### PR TITLE
fix: same type list

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -30,17 +30,11 @@ if GRAPHQL_SYNC_DATALOADERS_INSTALLED:
 
 class DjangoListField(Field):
     def __init__(self, _type, *args, **kwargs):
-        from .types import DjangoObjectType
-
         if isinstance(_type, NonNull):
             _type = _type.of_type
 
         # Django would never return a Set of None
         super().__init__(List(NonNull(_type)), *args, **kwargs)
-
-        assert issubclass(
-            self._underlying_type, DjangoObjectType
-        ), "DjangoListField only accepts DjangoObjectType types"
 
     @property
     def _underlying_type(self):
@@ -92,17 +86,11 @@ class DjangoDataloadedListField(Field):
         *args,
         **kwargs,
     ):
-        from graphene_django.types import DjangoObjectType
-
         if isinstance(_type, NonNull):
             _type = _type.of_type
 
         # Django would never return a Set of None
         super().__init__(List(NonNull(_type)), *args, **kwargs)
-
-        assert issubclass(
-            self._underlying_type, DjangoObjectType
-        ), "DjangoListField only accepts DjangoObjectType types"
 
         self._field = field
 

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -37,6 +37,15 @@ class DjangoListField(Field):
         super().__init__(List(NonNull(_type)), *args, **kwargs)
 
     @property
+    def type(self):
+        from .types import DjangoObjectType
+
+        assert issubclass(
+            self._underlying_type, DjangoObjectType
+        ), "DjangoListField only accepts DjangoObjectType types as underlying type"
+        return super().type
+
+    @property
     def _underlying_type(self):
         _type = self._type
         while hasattr(_type, "of_type"):
@@ -93,6 +102,15 @@ class DjangoDataloadedListField(Field):
         super().__init__(List(NonNull(_type)), *args, **kwargs)
 
         self._field = field
+
+    @property
+    def type(self):
+        from .types import DjangoObjectType
+
+        assert issubclass(
+            self._underlying_type, DjangoObjectType
+        ), "DjangoDataloadedListField only accepts DjangoObjectType types as underlying type"
+        return super().type
 
     @property
     def _underlying_type(self):

--- a/graphene_django/tests/models.py
+++ b/graphene_django/tests/models.py
@@ -6,6 +6,9 @@ CHOICES = ((1, "this"), (2, _("that")))
 
 class Person(models.Model):
     name = models.CharField(max_length=30)
+    parent = models.ForeignKey(
+        "self", on_delete=models.CASCADE, null=True, blank=True, related_name="children"
+    )
 
 
 class Pet(models.Model):

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,10 +1,11 @@
 import datetime
 import re
 
+import pytest
 from django.db.models import Count, Prefetch
 from graphql_sync_dataloaders import DeferredExecutionContext
 
-from graphene import List, NonNull, ObjectType, Schema
+from graphene import List, NonNull, ObjectType, Schema, String
 
 from ..fields import DjangoDataloadedListField, DjangoListField
 from ..types import DjangoObjectType
@@ -18,6 +19,13 @@ from .models import (
 
 
 class TestDjangoListField:
+    def test_only_django_object_types(self):
+        class Query(ObjectType):
+            something = DjangoListField(String)
+
+        with pytest.raises(TypeError):
+            Schema(query=Query)
+
     def test_only_import_paths(self):
         list_field = DjangoListField("graphene_django.tests.schema.Human")
         from .schema import Human

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,11 +1,10 @@
 import datetime
 import re
 
-import pytest
 from django.db.models import Count, Prefetch
 from graphql_sync_dataloaders import DeferredExecutionContext
 
-from graphene import List, NonNull, ObjectType, Schema, String
+from graphene import List, NonNull, ObjectType, Schema
 
 from ..fields import DjangoDataloadedListField, DjangoListField
 from ..types import DjangoObjectType
@@ -13,18 +12,12 @@ from .models import (
     Article as ArticleModel,
     Film as FilmModel,
     FilmDetails as FilmDetailsModel,
+    Person as PersonModel,
     Reporter as ReporterModel,
 )
 
 
 class TestDjangoListField:
-    def test_only_django_object_types(self):
-        class TestType(ObjectType):
-            foo = String()
-
-        with pytest.raises(AssertionError):
-            DjangoListField(TestType)
-
     def test_only_import_paths(self):
         list_field = DjangoListField("graphene_django.tests.schema.Human")
         from .schema import Human
@@ -260,6 +253,69 @@ class TestDjangoListField:
             "reporters": [
                 {"firstName": "Tara", "articles": [{"headline": "Amazing news"}]},
                 {"firstName": "Debra", "articles": []},
+            ]
+        }
+
+    def test_same_type_nested_list_field(self):
+        class Person(DjangoObjectType):
+            class Meta:
+                model = PersonModel
+                fields = ("name", "parent")
+
+            children = DjangoListField(lambda: Person)
+
+        class Query(ObjectType):
+            persons = DjangoListField(Person)
+
+        schema = Schema(query=Query)
+
+        query = """
+            query {
+                persons {
+                    name
+                    children {
+                        name
+                    }
+                }
+            }
+        """
+
+        p1 = PersonModel.objects.create(name="Tara")
+        PersonModel.objects.create(name="Debra")
+
+        PersonModel.objects.create(
+            name="Toto",
+            parent=p1,
+        )
+        PersonModel.objects.create(
+            name="Tata",
+            parent=p1,
+        )
+
+        result = schema.execute(query)
+
+        assert not result.errors
+        assert result.data == {
+            "persons": [
+                {
+                    "name": "Tara",
+                    "children": [
+                        {"name": "Toto"},
+                        {"name": "Tata"},
+                    ],
+                },
+                {
+                    "name": "Debra",
+                    "children": [],
+                },
+                {
+                    "name": "Toto",
+                    "children": [],
+                },
+                {
+                    "name": "Tata",
+                    "children": [],
+                },
             ]
         }
 


### PR DESCRIPTION
Fix for https://github.com/graphql-python/graphene-django/issues/1225

Currently a `DjangoListField` (or `DjangoDataloadedListField`) can't define a field to be a list of the same type than the root type. This is because `get_type()` gets executed in the context of the `DjangoObjectType`:

<img width="723" alt="Screenshot 2024-01-10 at 17 39 39" src="https://github.com/graphql-python/graphene-django/assets/26854828/70ba78eb-30b3-4502-a4c4-0cedbe31e68e">

`graphene` implementation of `List` is not affected by this because `get_type()` is executed under a different context and has access to the object:

<img width="745" alt="image" src="https://github.com/graphql-python/graphene-django/assets/26854828/787a2272-41db-4b6a-8255-8406d0ebd40b">