### PR TITLE
Bump version to 1.8.6

### DIFF
--- a/graphene_django/__init__.py
+++ b/graphene_django/__init__.py
@@ -2,7 +2,8 @@ from .fields import DjangoConnectionField, DjangoDataloadedListField, DjangoList
 from .types import DjangoObjectType
 from .utils import bypass_get_queryset
 
-__version__ = "3.2.3"
+# Upstream version: 3.2.3
+__version__ = "1.8.6"
 
 __all__ = [
     "__version__",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "graphene @ git+https://github.com/graphql-python/graphene.git@ee1ff975d71f6590eb6933d76d12054c9839774a#egg=graphene",
         "graphql-core>=3.1.0,<4",
         "graphql-relay>=3.1.1,<4",
-        "graphql-sync-dataloaders @ git+https://github.com/loft-orbital/graphql-sync-dataloaders.git@loft-1.0.2#egg=graphql-sync-dataloaders",
+        "graphql-sync-dataloaders @ git+https://github.com/loft-orbital/graphql-sync-dataloaders.git@loft-1.0.3#egg=graphql-sync-dataloaders",
         "Django>=3.2,<6",
         "promise>=2.1",
         "text-unidecode",


### PR DESCRIPTION
A [new tag](https://github.com/loft-orbital/graphql-sync-dataloaders/pull/7) was cut in graphql-sync-dataloaders to align its package version.
In the same way, we correct the version to align with the new tag to be cut after this PR is merged - `loft-1.8.6`.

Also, update our dependency on graphql-sync-dataloaders to its latest tag.